### PR TITLE
 fix: Always send a valid UA when running in a server

### DIFF
--- a/src/core/challengeFetcher.ts
+++ b/src/core/challengeFetcher.ts
@@ -1,4 +1,4 @@
-import { base64ToU8, buildURL, GOOG_API_KEY } from '../utils/index.js';
+import { base64ToU8, buildURL, getHeaders } from '../utils/index.js';
 import type { DescrambledChallenge, BgConfig } from '../utils/index.js';
 
 /**
@@ -21,11 +21,7 @@ export async function create(bgConfig: BgConfig, interpreterHash?: string): Prom
 
   const response = await bgConfig.fetch(buildURL('Create', bgConfig.useYouTubeAPI), {
     method: 'POST',
-    headers: {
-      'content-type': 'application/json+protobuf',
-      'x-goog-api-key': GOOG_API_KEY,
-      'x-user-agent': 'grpc-web-javascript/0.1'
-    },
+    headers: getHeaders(),
     body: JSON.stringify(payload)
   });
 

--- a/src/core/webPoClient.ts
+++ b/src/core/webPoClient.ts
@@ -1,6 +1,6 @@
 import BotGuardClient from './botGuardClient.js';
 import WebPoMinter from './webPoMinter.js';
-import { GOOG_API_KEY, base64ToU8, buildURL, u8ToBase64 } from '../utils/index.js';
+import { base64ToU8, buildURL, u8ToBase64, getHeaders } from '../utils/index.js';
 import type { PoTokenArgs, PoTokenResult, WebPoSignalOutput } from '../utils/index.js';
 
 /**
@@ -20,11 +20,7 @@ export async function generate(args: PoTokenArgs): Promise<PoTokenResult> {
 
   const integrityTokenResponse = await bgConfig.fetch(buildURL('GenerateIT', bgConfig.useYouTubeAPI), {
     method: 'POST',
-    headers: {
-      'content-type': 'application/json+protobuf',
-      'x-goog-api-key': GOOG_API_KEY,
-      'x-user-agent': 'grpc-web-javascript/0.1'
-    },
+    headers: getHeaders(),
     body: JSON.stringify(payload)
   });
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { GOOG_BASE_URL, YT_BASE_URL } from './constants.js';
+import { GOOG_API_KEY, GOOG_BASE_URL, USER_AGENT, YT_BASE_URL } from './constants.js';
 
 const base64urlCharRegex = /[-_.]/g;
 
@@ -21,13 +21,11 @@ export function base64ToU8(base64: string): Uint8Array {
 
   base64Mod = atob(base64Mod);
 
-  const result = new Uint8Array(
+  return new Uint8Array(
     [ ...base64Mod ].map(
       (char) => char.charCodeAt(0)
     )
   );
-
-  return result;
 }
 
 export function u8ToBase64(u8: Uint8Array, base64url = false): string {
@@ -40,6 +38,35 @@ export function u8ToBase64(u8: Uint8Array, base64url = false): string {
   }
 
   return result;
+}
+
+export function isBrowser(): boolean {
+  const isBrowser = typeof window !== 'undefined'
+    && typeof window.document !== 'undefined'
+    && typeof window.document.createElement !== 'undefined'
+    && typeof window.HTMLElement !== 'undefined'
+    && typeof window.navigator !== 'undefined'
+    && typeof window.getComputedStyle === 'function'
+    && typeof window.requestAnimationFrame === 'function'
+    && typeof window.matchMedia === 'function';
+
+  const hasValidWindow = Object.getOwnPropertyDescriptor(globalThis, 'window')?.get?.toString().includes('[native code]') ?? false;
+  
+  return isBrowser && hasValidWindow;
+}
+
+export function getHeaders() {
+  const headers: Record<string, any> = {
+    'content-type': 'application/json+protobuf',
+    'x-goog-api-key': GOOG_API_KEY,
+    'x-user-agent': 'grpc-web-javascript/0.1'
+  };
+  
+  if (!isBrowser()) {
+    headers['user-agent'] = USER_AGENT;
+  }
+  
+  return headers;
 }
 
 export function buildURL(endpointName: string, useYouTubeAPI?: boolean): string {


### PR DESCRIPTION
In previous versions of the library, it would always send a valid user agent regardless of the runtime environment. But at some point I removed it, since I only use this inside a real browser and it was causing me problems due to it being a forbidden header.

The problem with this is that when using it on the server, sending bad user agents or none at all will cause the the web attestation API to return an invalid integrity token at random, and thus an invalid WebPO is minted. 

This PR fixes that.