### PR TITLE
fix(BotGuardClient): Wait for vmFunctions to be set during load

### DIFF
--- a/examples/node/innertube-challenge-fetcher-example.ts
+++ b/examples/node/innertube-challenge-fetcher-example.ts
@@ -72,7 +72,7 @@ const integrityTokenBasedMinter = await BG.WebPoMinter.create({ integrityToken: 
 // #endregion
 
 // #region YouTube.js Usage Example
-const videoId = 'EBFDLgqn8pw';
+const videoId = '7eLARwNIjDY';
 
 const contentPoToken = await integrityTokenBasedMinter.mintAsWebsafeString(videoId);
 const sessionPoToken = await integrityTokenBasedMinter.mintAsWebsafeString(visitorData);

--- a/src/core/botGuardClient.ts
+++ b/src/core/botGuardClient.ts
@@ -30,6 +30,11 @@ export default class BotGuardClient {
     if (!this.vm.a)
       throw new BGError('[BotGuardClient]: Could not load program');
 
+    let vmFunctionsCallbackCalled: () => void;
+    const vmFunctionsCallbackPromise = new Promise<void>((resolve) => {
+      vmFunctionsCallbackCalled = resolve;
+    });
+
     const vmFunctionsCallback = (
       asyncSnapshotFunction: VMFunctions['asyncSnapshotFunction'],
       shutdownFunction: VMFunctions['shutdownFunction'],
@@ -37,6 +42,7 @@ export default class BotGuardClient {
       checkCameraFunction: VMFunctions['checkCameraFunction']
     ) => {
       Object.assign(this.vmFunctions, { asyncSnapshotFunction, shutdownFunction, passEventFunction, checkCameraFunction });
+      vmFunctionsCallbackCalled();
     };
 
     try {
@@ -44,6 +50,8 @@ export default class BotGuardClient {
     } catch (error) {
       throw new BGError(`[BotGuardClient]: Failed to load program (${(error as Error).message})`);
     }
+
+    await vmFunctionsCallbackPromise;
 
     return this;
   }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -8,9 +8,22 @@ const base64urlToBase64Map = {
   '.': '='
 };
 
+export class DeferredPromise<T = any> {
+  public promise: Promise<T>;
+  public resolve!: (value: T | PromiseLike<T>) => void;
+  public reject!: (reason?: any) => void;
+  
+  constructor() {
+    this.promise = new Promise((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+}
+
 export class BGError extends TypeError {
   public info?: any;
-  
+
   constructor(message: string, info?: Record<string, any>) {
     super(message);
     this.name = 'BGError';
@@ -62,7 +75,7 @@ export function isBrowser(): boolean {
     && typeof window.matchMedia === 'function';
 
   const hasValidWindow = Object.getOwnPropertyDescriptor(globalThis, 'window')?.get?.toString().includes('[native code]') ?? false;
-  
+
   return isBrowser && hasValidWindow;
 }
 
@@ -72,11 +85,11 @@ export function getHeaders() {
     'x-goog-api-key': GOOG_API_KEY,
     'x-user-agent': 'grpc-web-javascript/0.1'
   };
-  
+
   if (!isBrowser()) {
     headers['user-agent'] = USER_AGENT;
   }
-  
+
   return headers;
 }
 


### PR DESCRIPTION
In web browsers it looks like the `vmFunctionsCallback` is called after `await this.vm.a()` returns, so if you try calling `await botGuard.snapshot()` right after calling `await BotGuardClient.create()`, it will throw a `[BotGuardClient]: Async snapshot function not found` error. The existing workaround was to add an arbitrary timeout between the two calls. Doing it this way means we can return as soon as possible and don't have to use some unpredictable timeout.